### PR TITLE
feat: add perfect shader presets

### DIFF
--- a/skeleton/BASE/Shaders/crt-perfect.cfg
+++ b/skeleton/BASE/Shaders/crt-perfect.cfg
@@ -1,0 +1,16 @@
+minarch_nrofshaders = 1
+minarch_shader1 = crt-perfect.glsl
+minarch_shader1_filter = LINEAR
+minarch_shader1_srctype = source
+minarch_shader1_scaletype = source
+minarch_shader1_upscale = screen
+minarch_scale_filter = LINEAR
+
+cp_scanlines = 0.60
+cp_rgb_mask = 0.05
+cp_mask_type = 1.00
+cp_mask_size = 1.00
+cp_min_pitch = 5.00
+cp_curvature = 0.00
+cp_brightness = 1.50
+cp_gamma = 1.00

--- a/skeleton/BASE/Shaders/dmg-perfect.cfg
+++ b/skeleton/BASE/Shaders/dmg-perfect.cfg
@@ -1,0 +1,15 @@
+minarch_nrofshaders = 1
+minarch_shader1 = dmg-perfect.glsl
+minarch_shader1_filter = LINEAR
+minarch_shader1_srctype = source
+minarch_shader1_scaletype = source
+minarch_shader1_upscale = screen
+minarch_scale_filter = LINEAR
+
+dp_grid = 0.30
+dp_gap = 1.00
+dp_shadow = 0.20
+dp_brightness = 1.75
+dp_gamma = 1.50
+dp_temperature = -0.12
+dp_tint = -0.15

--- a/skeleton/BASE/Shaders/glsl/crt-perfect.glsl
+++ b/skeleton/BASE/Shaders/glsl/crt-perfect.glsl
@@ -1,0 +1,251 @@
+// crt-perfect v14 - scanlines, an RGB mask and curvature, pixel-perfect scale.
+// -----------------------------------------------------------------------------
+// Author:  sinedied
+// Licence: MIT - Copyright (c) 2026 sinedied
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions: the above copyright
+// notice and this permission notice shall be included in all copies or
+// substantial portions of the Software. THE SOFTWARE IS PROVIDED "AS IS",
+// WITHOUT WARRANTY OF ANY KIND.
+// -----------------------------------------------------------------------------
+// PARAMETERS
+//
+//   cp_scanlines   0.00 - 1.00  Scanline visibility. 0 disables them.
+//   cp_rgb_mask    0.00 - 1.00  RGB mask visibility. 0 disables it.
+//   cp_mask_type   0 / 1 / 2    Off, aperture grille, slot grille.
+//   cp_mask_size   0.25 - 2.00  Mask triads per source pixel.
+//   cp_min_pitch   2.00 - 6.00  Smallest pattern pitch, in output pixels.
+//   cp_curvature   0.00 - 0.15  Screen curvature. 0 disables it.
+//   cp_brightness  0.25 - 4.00  Output gain. 1.00 disables it.
+//   cp_gamma       0.50 - 2.00  Output gamma. 1.00 disables it.
+// -----------------------------------------------------------------------------
+// A CRT look: soft scanlines and an RGB shadow mask over a clean pixel scale,
+// with optional screen curvature. Reads like a small tube TV, sharp rather than
+// blurry, and neither pattern beats against the pixel grid at any scale.
+//
+// Notes:
+// - Needs a LINEAR filter, set in the preset. Under NEAREST the scale becomes
+//   ordinary nearest-neighbour and the picture gets ragged edges.
+// - Render at the output resolution, 1:1 with the display.
+// - At min. pitch 2.00 the mask becomes 2 colours: use 2.50 or more to keep
+//   the triads visible.
+// - Brightness above 1.00 clips, may create pattern artifacts against the
+//   pixel grid unless the output is an integer scale.
+
+#pragma parameter cp_scanlines  "Scanline visibility"        0.60 0.00 1.00 0.05
+#pragma parameter cp_rgb_mask   "RGB mask visibility"        0.20 0.00 1.00 0.05
+#pragma parameter cp_mask_type  "Mask 0=off 1=grille 2=slot" 1.00 0.00 2.00 1.00
+#pragma parameter cp_mask_size  "Mask triads per pixel"      1.00 0.25 2.00 0.25
+#pragma parameter cp_min_pitch  "Min. pitch in px"           3.00 2.00 6.00 0.25
+#pragma parameter cp_curvature  "Screen curvature"           0.00 0.00 0.15 0.01
+#pragma parameter cp_brightness "Brightness"                 1.25 0.25 4.00 0.05
+#pragma parameter cp_gamma      "Gamma"                      1.00 0.50 2.00 0.05
+
+#if defined(VERTEX)
+
+#if __VERSION__ >= 130
+#define COMPAT_VARYING out
+#define COMPAT_ATTRIBUTE in
+#define COMPAT_TEXTURE texture
+#else
+#define COMPAT_VARYING varying
+#define COMPAT_ATTRIBUTE attribute
+#define COMPAT_TEXTURE texture2D
+#endif
+
+#ifdef GL_ES
+#define COMPAT_PRECISION mediump
+#else
+#define COMPAT_PRECISION
+#endif
+
+COMPAT_ATTRIBUTE vec4 VertexCoord;
+COMPAT_ATTRIBUTE vec4 COLOR;
+COMPAT_ATTRIBUTE vec4 TexCoord;
+COMPAT_VARYING vec4 COL0;
+COMPAT_VARYING vec4 TEX0;
+
+uniform mat4 MVPMatrix;
+uniform COMPAT_PRECISION int FrameDirection;
+uniform COMPAT_PRECISION int FrameCount;
+uniform COMPAT_PRECISION vec2 OutputSize;
+uniform COMPAT_PRECISION vec2 TextureSize;
+uniform COMPAT_PRECISION vec2 InputSize;
+
+void main()
+{
+    gl_Position = MVPMatrix * VertexCoord;
+    COL0 = COLOR;
+    TEX0.xy = TexCoord.xy;
+}
+
+#elif defined(FRAGMENT)
+
+#if __VERSION__ >= 130
+#define COMPAT_VARYING in
+#define COMPAT_TEXTURE texture
+out vec4 FragColor;
+#else
+#define COMPAT_VARYING varying
+#define FragColor gl_FragColor
+#define COMPAT_TEXTURE texture2D
+#endif
+
+#ifdef GL_ES
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+precision highp float;
+#else
+precision mediump float;
+#endif
+#define COMPAT_PRECISION highp
+#else
+#define COMPAT_PRECISION
+#endif
+
+uniform COMPAT_PRECISION int FrameDirection;
+uniform COMPAT_PRECISION int FrameCount;
+uniform COMPAT_PRECISION vec2 OutputSize;
+uniform COMPAT_PRECISION vec2 TextureSize;
+uniform COMPAT_PRECISION vec2 InputSize;
+uniform sampler2D Texture;
+COMPAT_VARYING vec4 TEX0;
+
+#define Source Texture
+#define vTexCoord TEX0.xy
+#define outsize vec4(OutputSize, 1.0 / OutputSize)
+
+#define PI  3.141592654
+#define TAU 6.283185307
+
+#ifdef PARAMETER_UNIFORM
+uniform COMPAT_PRECISION float cp_scanlines;
+uniform COMPAT_PRECISION float cp_rgb_mask;
+uniform COMPAT_PRECISION float cp_mask_type;
+uniform COMPAT_PRECISION float cp_mask_size;
+uniform COMPAT_PRECISION float cp_brightness;
+uniform COMPAT_PRECISION float cp_min_pitch;
+uniform COMPAT_PRECISION float cp_gamma;
+uniform COMPAT_PRECISION float cp_curvature;
+#else
+#define cp_scanlines 0.60
+#define cp_rgb_mask 0.20
+#define cp_mask_type 1.00
+#define cp_mask_size 1.00
+#define cp_brightness 1.25
+#define cp_min_pitch 3.00
+#define cp_gamma 1.00
+#define cp_curvature 0.00
+#endif
+
+// Average of a unit sinusoid of frequency f, in cycles per output pixel, over
+// one pixel-wide box. Reaches zero at one cycle per pixel.
+float boxSinc(float f)
+{
+    float x = PI * max(f, 1e-4);
+    return sin(x) / x;
+}
+
+// Nothing above Nyquist can be drawn, so fade the pattern out entirely there -
+// amplitude and darkening together, leaving no uniform dimming behind.
+float nyquistFade(float f)
+{
+    return 1.0 - smoothstep(0.34, 0.5, f);
+}
+
+void main()
+{
+    vec2  uv   = vTexCoord;
+    float tube = 1.0;
+    float noWarp = 1.0;
+
+    if (cp_curvature > 0.0) {
+        // Dividing by the edge-midpoint value keeps the image edges on the
+        // screen edges, so only the corners curve away and nothing is cropped.
+        float norm = 1.0 / (1.0 + cp_curvature);
+        vec2  c    = uv * 2.0 - 1.0;
+        vec2  cc   = c * c;
+        float r2   = cc.x + cc.y;
+
+        uv  = c * (1.0 + cp_curvature * r2) * norm * 0.5 + 0.5;
+        noWarp = 0.0;
+
+        // The corners now sample past the image, where the sampler would
+        // stretch the border texel; mask them instead.
+        vec2 e  = outsize.zw;
+        vec2 aa = clamp(uv / e, 0.0, 1.0) * clamp((1.0 - uv) / e, 0.0, 1.0);
+        tube = aa.x * aa.y;
+    }
+
+    // h is deliberately independent of the warp: it keeps everything below it
+    // uniform across the draw, which the driver can then compute once.
+    vec2 p = uv * TextureSize;
+    vec2 h = max(0.4995 * InputSize / OutputSize, 1e-6);
+
+    // B is the nearest texel boundary and w the share of the footprint on its
+    // low side, handed to the texture unit: one LINEAR tap returns the blend.
+    vec2 B = floor(p + 0.5);
+    vec2 w = clamp((B - p + h) / (2.0 * h), 0.0, 1.0);
+    vec3 color = COMPAT_TEXTURE(Source, (B + 0.5 - w) / TextureSize).rgb;
+
+    // The base is clamped because pow(0, g) is undefined and returns NaN on
+    // real drivers. 1e-8, not 1e-5, which would lift pure black to 1/255.
+    if (abs(cp_gamma - 1.0) > 0.001) {
+        color = pow(max(color, 1e-8), vec3(cp_gamma));
+    }
+
+    float scanSrcPitch = OutputSize.y / max(InputSize.y, 1.0);
+    float scanPitch    = max(scanSrcPitch, cp_min_pitch);
+    float scanLocked   = (1.0 - smoothstep(cp_min_pitch * 1.001, cp_min_pitch * 1.02, scanSrcPitch)) * noWarp;
+    float scanFreq     = 1.0 / scanPitch;
+
+    // The flat pitch, used even under curvature: it holds the pattern to one
+    // cycle per source line, and keeps this uniform across the draw.
+    float scanLocal    = scanFreq;
+
+    float scanAmp = cp_scanlines * mix(nyquistFade(scanLocal), 1.0, scanLocked);
+    float scanAC  = 0.5 * scanAmp * mix(boxSinc(scanLocal), 1.0, scanLocked);
+
+    float scan = 1.0;
+    if (scanAmp > 0.0) {
+        float y = uv.y * OutputSize.y - 0.5 * scanLocked;
+        scan = (1.0 - 0.5 * scanAmp) - scanAC * cos(TAU * fract(y * scanFreq));
+    }
+
+    float maskSrcPitch = OutputSize.x / max(InputSize.x * cp_mask_size, 1.0);
+    float maskPitch    = max(maskSrcPitch, cp_min_pitch);
+    float maskLocked   = (1.0 - smoothstep(cp_min_pitch * 1.001, cp_min_pitch * 1.02, maskSrcPitch)) * noWarp;
+    float maskFreq     = 1.0 / maskPitch;
+    float maskLocal    = maskFreq;
+
+    float maskAmp = cp_rgb_mask * mix(nyquistFade(maskLocal), 1.0, maskLocked);
+
+    vec3 mask = vec3(1.0);
+    if (maskAmp > 0.0 && cp_mask_type >= 0.5) {
+        float x = uv.x * OutputSize.x - 0.5 * maskLocked;
+        float phase = x * maskFreq - (1.0 / 6.0);
+
+        if (cp_mask_type >= 1.5) {
+            float row = floor((uv.y * OutputSize.y - 0.5 * scanLocked) * scanFreq + 1e-3);
+            phase += 0.5 * mod(row, 2.0);
+        }
+
+        float dc = 1.0 - 0.5 * maskAmp;
+        float ac = 0.5 * maskAmp * mix(boxSinc(maskLocal), 1.0, maskLocked);
+        mask.rg = dc + ac * cos(TAU * (fract(phase) - vec2(0.0, 1.0 / 3.0)));
+        mask.b  = max(3.0 * dc - mask.r - mask.g, 0.0);
+    }
+
+    // Brightness rides the pattern, so the clamp below lands on the product.
+    // Clamping the picture instead flattens highlights before the mask shapes
+    // them.
+    vec3 gain = sqrt(max(mask * (scan * cp_brightness), 0.0));
+
+    FragColor = vec4(clamp(color * gain * tube, 0.0, 1.0), 1.0);
+}
+
+#endif

--- a/skeleton/BASE/Shaders/glsl/dmg-perfect.glsl
+++ b/skeleton/BASE/Shaders/glsl/dmg-perfect.glsl
@@ -1,0 +1,231 @@
+// dmg-perfect v11 - a Game Boy dot matrix over a pixel-perfect scale.
+// -----------------------------------------------------------------------------
+// Licence: MIT - Copyright (c) 2026 sinedied
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions: the above copyright
+// notice and this permission notice shall be included in all copies or
+// substantial portions of the Software. THE SOFTWARE IS PROVIDED "AS IS",
+// WITHOUT WARRANTY OF ANY KIND.
+// -----------------------------------------------------------------------------
+// PARAMETERS
+//
+//   dp_grid           0.00 - 1.00  Grid visibility. 0 disables it.
+//   dp_gap            0.25 - 2.00  Grid line thickness, in pixels.
+//   dp_shadow         0.00 - 1.00  Shadow cast by driven dots. 0 disables it.
+//   dp_brightness     0.25 - 4.00  Output gain. 1.00 disables it.
+//   dp_gamma          0.50 - 2.00  Output gamma. 1.00 disables it.
+//   dp_temperature   -1.00 - 1.00  Warm above 0, cool below. 0.00 is off.
+//   dp_tint          -1.00 - 1.00  Green above 0, magenta below. 0.00 is off.
+// -----------------------------------------------------------------------------
+// An original Game Boy look: the dot matrix grid with its pale gaps, over a
+// clean pixel scale. Dots can cast a shadow so they sit above the panel. The
+// grid is invisible on white and strongest on dark content, as a real DMG is.
+//
+// Notes:
+// - Needs a LINEAR filter, set in the preset. Under NEAREST the scale becomes
+//   ordinary nearest-neighbour and the picture gets ragged edges.
+// - Render at the output resolution, 1:1 with the display.
+// - Grid line thickness is in output pixels, so the panel reads the same at
+//   every resolution. 1.00 is a one-pixel line.
+// - Brightness above 1.00 clips, may create pattern artifacts against the
+//   pixel grid unless the output is an integer scale.
+
+#pragma parameter dp_grid        "Grid visibility"          0.30  0.00 1.00 0.01
+#pragma parameter dp_gap         "Grid line thickness"      1.00  0.25 2.00 0.05
+#pragma parameter dp_shadow      "Dot shadow"               0.00  0.00 1.00 0.01
+#pragma parameter dp_brightness  "Brightness"               1.00  0.25 4.00 0.05
+#pragma parameter dp_gamma       "Gamma"                    1.20  0.50 2.00 0.05
+#pragma parameter dp_temperature "Cool / warm balance"      0.00 -1.00 1.00 0.01
+#pragma parameter dp_tint        "Magenta / green balance"  0.00 -1.00 1.00 0.01
+
+#if defined(VERTEX)
+
+#if __VERSION__ >= 130
+#define COMPAT_VARYING out
+#define COMPAT_ATTRIBUTE in
+#define COMPAT_TEXTURE texture
+#else
+#define COMPAT_VARYING varying
+#define COMPAT_ATTRIBUTE attribute
+#define COMPAT_TEXTURE texture2D
+#endif
+
+#ifdef GL_ES
+#define COMPAT_PRECISION mediump
+#else
+#define COMPAT_PRECISION
+#endif
+
+COMPAT_ATTRIBUTE vec4 VertexCoord;
+COMPAT_ATTRIBUTE vec4 COLOR;
+COMPAT_ATTRIBUTE vec4 TexCoord;
+COMPAT_VARYING vec4 COL0;
+COMPAT_VARYING vec4 TEX0;
+
+uniform mat4 MVPMatrix;
+uniform COMPAT_PRECISION int FrameDirection;
+uniform COMPAT_PRECISION int FrameCount;
+uniform COMPAT_PRECISION vec2 OutputSize;
+uniform COMPAT_PRECISION vec2 TextureSize;
+uniform COMPAT_PRECISION vec2 InputSize;
+
+void main()
+{
+    gl_Position = MVPMatrix * VertexCoord;
+    COL0 = COLOR;
+    TEX0.xy = TexCoord.xy;
+}
+
+#elif defined(FRAGMENT)
+
+#if __VERSION__ >= 130
+#define COMPAT_VARYING in
+#define COMPAT_TEXTURE texture
+out vec4 FragColor;
+#else
+#define COMPAT_VARYING varying
+#define FragColor gl_FragColor
+#define COMPAT_TEXTURE texture2D
+#endif
+
+#ifdef GL_ES
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+precision highp float;
+#else
+precision mediump float;
+#endif
+#define COMPAT_PRECISION highp
+#else
+#define COMPAT_PRECISION
+#endif
+
+uniform COMPAT_PRECISION int FrameDirection;
+uniform COMPAT_PRECISION int FrameCount;
+uniform COMPAT_PRECISION vec2 OutputSize;
+uniform COMPAT_PRECISION vec2 TextureSize;
+uniform COMPAT_PRECISION vec2 InputSize;
+uniform sampler2D Texture;
+COMPAT_VARYING vec4 TEX0;
+
+#ifdef PARAMETER_UNIFORM
+uniform COMPAT_PRECISION float dp_grid;
+uniform COMPAT_PRECISION float dp_gap;
+uniform COMPAT_PRECISION float dp_shadow;
+uniform COMPAT_PRECISION float dp_brightness;
+uniform COMPAT_PRECISION float dp_gamma;
+uniform COMPAT_PRECISION float dp_temperature;
+uniform COMPAT_PRECISION float dp_tint;
+#else
+#define dp_grid 0.30
+#define dp_gap 1.0
+#define dp_shadow 0.0
+#define dp_brightness 1.0
+#define dp_gamma 1.2
+#define dp_temperature 0.0
+#define dp_tint 0.0
+#endif
+
+// The substrate a DMG's gaps show: undriven crystal at its lightest state.
+#define DMG_SUBSTRATE 1.0
+
+#define LUMA vec3(0.299, 0.587, 0.114)
+
+// Floor under the paper level the shadow measures opacity against. Must sit
+// below the darkest palette anyone ships.
+#define PAPER_FLOOR 0.35
+
+// In source pixels, so the shadow holds its proportions at every scale.
+#define SHADOW_OFFSET vec2(0.45, 0.85)
+
+// Extra half-width on the box that samples the displaced aperture. Softens the
+// aperture's gaps only; the shadow's outer edge comes from the opacity field.
+#define APERTURE_SOFT 0.5
+
+// Antiderivative of the dot profile. Differencing it gives the exact box mean.
+// Peak-normalised, so it is a coverage mask topping out at 1.
+vec2 dotInt(vec2 x, vec2 w)
+{
+    vec2 n = floor(x);
+    return n * w + clamp(x - n, vec2(0.0), w);
+}
+
+void main()
+{
+    // Source texels. The max() guards an unset uniform, which is 0 and would
+    // make h a zero divisor below.
+    vec2 p = TEX0.xy * TextureSize;
+    vec2 h = max(0.4995 * InputSize / OutputSize, 1e-6);
+    vec2 B = floor(p + 0.5);
+
+    // N is the whole scale that fits, so a dp_gap line is dp_gap/N of a cell
+    // and stays a pixel wide at any scale. The nudge guards floor() on a
+    // division landing a ULP short.
+    vec2 sc = OutputSize / max(InputSize, 1.0);
+    float N = max(floor(min(sc.x, sc.y) + 1e-3), 1.0);
+    vec2 lit = clamp(vec2(1.0 - dp_gap / N), 1e-3, 1.0);
+
+    // Coverage of the lit dot over this output pixel, exactly, per axis.
+    vec2 cov = max(dotInt(p + h, lit) - dotInt(p - h, lit), vec2(1e-6))
+               / (2.0 * h);
+
+    // Below two output pixels per cell the pattern folds to a coarser pitch,
+    // so it has to reach zero at two, not at one.
+    cov = mix(vec2(1.0), cov, smoothstep(vec2(2.0), vec2(2.9), sc));
+    float dot2d = cov.x * cov.y;
+
+    // B is the nearest texel boundary and w the share of the footprint on its
+    // low side, handed to the texture unit: one LINEAR tap returns the blend.
+    vec2 w = clamp((B - p + h) / (2.0 * h), 0.0, 1.0);
+    vec3 area = COMPAT_TEXTURE(Texture, (B + 0.5 - w) / TextureSize).rgb;
+
+    // Not applied to the SUBSTRATE, so brightening lifts the dots toward a
+    // fixed paper rather than washing the whole panel out.
+    vec3 grade = (1.0 + dp_temperature * vec3(1.0, 0.0, -1.0)
+                      + dp_tint        * vec3(-0.5, 1.0, -0.5)) * dp_brightness;
+
+    // Gaps show the substrate, dots show the picture; k is the share of this
+    // pixel reading as gap.
+    float k = dp_grid * (1.0 - dot2d);
+    vec3 col = mix(area * grade, vec3(DMG_SUBSTRATE), k);
+
+    // Multiplies everything rather than darkening the gap colour, which is
+    // what puts the shadow underneath the dots.
+    if (dp_shadow > 0.0) {
+        // In source pixels, so the offset is a fixed fraction of a cell.
+        vec2 q = p - SHADOW_OFFSET;
+
+        // The dot's own shape, displaced and widened: a box blur of it.
+        vec2 hs = h + APERTURE_SOFT;
+        vec2 covS = max(dotInt(q + hs, lit) - dotInt(q - hs, lit), vec2(0.0))
+                    / (2.0 * hs);
+        covS = mix(vec2(1.0), covS, smoothstep(vec2(2.0), vec2(2.9), sc));
+
+        // dot() is linear, so the luma of a blend is the blend of lumas and
+        // one tap suffices.
+        float casterLum = dot(COMPAT_TEXTURE(Texture, q / TextureSize).rgb, LUMA);
+
+        // The undriven level to measure opacity against - not white, since no
+        // Game Boy palette is near it.
+        float paper = max(dot(area, LUMA), PAPER_FLOOR);
+
+        // Both sides raw, so an output gain cancels out of the ratio.
+        float opacity = clamp(1.0 - casterLum / paper, 0.0, 1.0);
+
+        col *= 1.0 - dp_shadow * opacity * covS.x * covS.y;
+    }
+
+    // The base is clamped because pow(0, g) is undefined and returns NaN on
+    // real drivers. 1e-8, not 1e-5, which would lift pure black to 1/255.
+    if (abs(dp_gamma - 1.0) > 0.001) {
+        col = pow(max(col, 1e-8), vec3(dp_gamma));
+    }
+
+    FragColor = vec4(clamp(col, 0.0, 1.0), 1.0);
+}
+
+#endif

--- a/skeleton/BASE/Shaders/glsl/lcd-perfect.glsl
+++ b/skeleton/BASE/Shaders/glsl/lcd-perfect.glsl
@@ -1,0 +1,258 @@
+// lcd-perfect v10 - an LCD matrix and RGB stripes over a pixel-perfect scale.
+// -----------------------------------------------------------------------------
+// Licence: MIT - Copyright (c) 2026 sinedied
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions: the above copyright
+// notice and this permission notice shall be included in all copies or
+// substantial portions of the Software. THE SOFTWARE IS PROVIDED "AS IS",
+// WITHOUT WARRANTY OF ANY KIND.
+// -----------------------------------------------------------------------------
+// PARAMETERS
+//
+//   lp_grid        0.00 - 1.00  Grid visibility. 0 disables it.
+//   lp_balance     0.00 - 1.00  Row/column balance. 0 rows, 1 columns.
+//   lp_min_pitch   2.00 - 6.00  Smallest pattern pitch, in output pixels.
+//   lp_subpixels   0.00 - 1.00  RGB stripe visibility. 0 disables them.
+//   lp_layout      0 / 1        Stripe order: RGB or BGR.
+//   lp_brightness  0.25 - 4.00  Output gain. 1.00 disables it.
+//   lp_gamma       0.50 - 2.00  Output gamma. 1.00 disables it.
+// -----------------------------------------------------------------------------
+// A handheld LCD look: a soft backlit mesh with RGB subpixel stripes, over a
+// clean pixel scale. Reads like a Game Boy Color or GBA screen in good light -
+// a gentle grid rather than a hard black matrix, and it stays even at every
+// scale instead of breaking into a pattern.
+//
+// Notes:
+// - Needs a LINEAR filter, set in the preset. Under NEAREST the scale becomes
+//   ordinary nearest-neighbour and the picture gets ragged edges.
+// - Render at the output resolution, 1:1 with the display.
+// - Row/column balance sets which axis dominates. Real panels are row-dominant;
+//   0.80 or so matches lcd1x.
+// - Brightness above 1.00 clips, may create pattern artifacts against the
+//   pixel grid unless the output is an integer scale.
+
+#pragma parameter lp_grid       "Grid visibility"          0.30 0.00 1.00 0.01
+#pragma parameter lp_balance    "Row/column balance"       0.60 0.00 1.00 0.01
+#pragma parameter lp_min_pitch  "Minimum pitch in px"      3.00 2.00 6.00 0.25
+#pragma parameter lp_subpixels  "RGB stripe visibility"    0.20 0.00 1.00 0.05
+#pragma parameter lp_layout     "Stripe order 0=RGB 1=BGR" 0.00 0.00 1.00 1.00
+#pragma parameter lp_brightness "Brightness"               1.25 0.25 4.00 0.05
+#pragma parameter lp_gamma      "Gamma"                    1.00 0.50 2.00 0.05
+
+#if defined(VERTEX)
+
+#if __VERSION__ >= 130
+#define COMPAT_VARYING out
+#define COMPAT_ATTRIBUTE in
+#define COMPAT_TEXTURE texture
+#else
+#define COMPAT_VARYING varying
+#define COMPAT_ATTRIBUTE attribute
+#define COMPAT_TEXTURE texture2D
+#endif
+
+#ifdef GL_ES
+#define COMPAT_PRECISION mediump
+#else
+#define COMPAT_PRECISION
+#endif
+
+COMPAT_ATTRIBUTE vec4 VertexCoord;
+COMPAT_ATTRIBUTE vec4 COLOR;
+COMPAT_ATTRIBUTE vec4 TexCoord;
+COMPAT_VARYING vec4 COL0;
+COMPAT_VARYING vec4 TEX0;
+
+uniform mat4 MVPMatrix;
+uniform COMPAT_PRECISION int FrameDirection;
+uniform COMPAT_PRECISION int FrameCount;
+uniform COMPAT_PRECISION vec2 OutputSize;
+uniform COMPAT_PRECISION vec2 TextureSize;
+uniform COMPAT_PRECISION vec2 InputSize;
+
+void main()
+{
+    gl_Position = MVPMatrix * VertexCoord;
+    COL0 = COLOR;
+    TEX0.xy = TexCoord.xy;
+}
+
+#elif defined(FRAGMENT)
+
+#if __VERSION__ >= 130
+#define COMPAT_VARYING in
+#define COMPAT_TEXTURE texture
+out vec4 FragColor;
+#else
+#define COMPAT_VARYING varying
+#define FragColor gl_FragColor
+#define COMPAT_TEXTURE texture2D
+#endif
+
+#ifdef GL_ES
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+precision highp float;
+#else
+precision mediump float;
+#endif
+#define COMPAT_PRECISION highp
+#else
+#define COMPAT_PRECISION
+#endif
+
+uniform COMPAT_PRECISION int FrameDirection;
+uniform COMPAT_PRECISION int FrameCount;
+uniform COMPAT_PRECISION vec2 OutputSize;
+uniform COMPAT_PRECISION vec2 TextureSize;
+uniform COMPAT_PRECISION vec2 InputSize;
+uniform sampler2D Texture;
+COMPAT_VARYING vec4 TEX0;
+
+#ifdef PARAMETER_UNIFORM
+uniform COMPAT_PRECISION float lp_grid;
+uniform COMPAT_PRECISION float lp_balance;
+uniform COMPAT_PRECISION float lp_min_pitch;
+uniform COMPAT_PRECISION float lp_subpixels;
+uniform COMPAT_PRECISION float lp_layout;
+uniform COMPAT_PRECISION float lp_brightness;
+uniform COMPAT_PRECISION float lp_gamma;
+#else
+#define lp_grid 0.30
+#define lp_balance 0.60
+#define lp_min_pitch 3.00
+#define lp_subpixels 0.20
+#define lp_layout 0.0
+#define lp_brightness 1.25
+#define lp_gamma 1.00
+#endif
+
+#define TAU 6.283185307
+#define PI  3.141592654
+
+// cos and sin of TAU/6, the angle from a cell's centre to the red stripe.
+// Green sits half a turn from there, so its pair is (-1, 0) and costs nothing.
+#define COS_TAU_6 0.5
+#define SIN_TAU_6 0.866025404
+
+// Mean of a unit sinusoid over one output pixel. The mesh gets this exactly
+// from the integral below; the stripes are sampled, so they need it named.
+float boxSinc(float f)
+{
+    float x = PI * max(f, 1e-4);
+    return sin(x) / x;
+}
+
+// Past Nyquist the pattern would fold to a coarser pitch at nearly full
+// strength, so take it out entirely instead.
+vec2 nyquistFade(vec2 f)
+{
+    return 1.0 - smoothstep(0.34, 0.5, f);
+}
+
+void main()
+{
+    vec2 p = TEX0.xy * TextureSize;
+    vec2 d = max(InputSize / OutputSize, 1e-6);
+    vec2 B = floor(p + 0.5);
+
+    // Cells per period: a WHOLE number of cells, never a fixed pixel size, so
+    // the pattern stays periodic on the source grid. The bias is load-bearing -
+    // a/b is a*rcp(b), so a ratio of exactly 1 can land a hair above it.
+    vec2 N = max(ceil(lp_min_pitch * d - 1e-4), 1.0);
+
+    vec2 f = d / N;
+
+    // A sinusoid does not band-limit itself, so this cannot be dropped.
+    vec2 fade = nyquistFade(f);
+
+    // Once a period spans several cells only one boundary in N carries a line,
+    // so the amplitude is spread back out. N == 1 is untouched.
+    vec2 amp = clamp(lp_grid * 2.0 * vec2(lp_balance, 1.0 - lp_balance), 0.0, 1.0)
+               * fade * (2.0 / (N + 1.0));
+
+    // Half an output pixel, in cycles: puts one sample per cycle on the
+    // trough, which is what lets a two-pixel pitch resolve at all.
+    vec2 phase = 0.5 * f;
+
+    // The pattern coordinate, in periods. With N == 1 this is exactly p.
+    vec2 t  = p / N;
+    vec2 hh = 0.4995 * f;
+
+    // The aperture integral over the footprint, the exact box filter. Both ends
+    // are symmetric about X, so one sin and one cos of X do the work of four
+    // and the stripes below reuse the pair.
+    vec2 X    = TAU * (t - phase);
+    vec2 sinX = sin(X);
+    vec2 cosX = cos(X);
+
+    vec2 Y    = TAU * hh;
+    vec2 sinY = sin(Y);
+    vec2 cosY = cos(Y);
+    vec2 k    = amp / TAU;
+
+    // Alo must use the UNCLAMPED Iraw, or the two disagree where I clamps.
+    vec2 Iraw = 2.0 * hh - k * (2.0 * cosX * sinY);
+    vec2 Alo  = t - 0.5 * Iraw - (k * cosY) * sinX;
+    vec2 I    = max(Iraw, 1e-6);
+
+    // Peak-normalised, so the flat top lands at 1 and nothing meets the clamp.
+    vec2 g = I * (1.0 / (2.0 * hh * (1.0 + amp)));
+    float gain = g.x * g.y;
+
+    // The mesh's dark line and the scaler's transition pixel both sit on the
+    // cell boundary, so the blend is weighted by aperture, not by area.
+    vec2 Bt  = B / N;
+    vec2 AB  = Bt - k * sin(TAU * (Bt - phase));
+    vec2 w   = clamp((AB - Alo) / I, 0.0, 1.0);
+
+    // One LINEAR tap, handed the weights above: this texcoord asks the texture
+    // unit for exactly mix(T[B], T[B-1], w).
+    vec3 color = COMPAT_TEXTURE(Texture, (B + 0.5 - w) / TextureSize).rgb;
+
+    // Three sinusoids 120 degrees apart, summing to exactly 3 at every pixel,
+    // so they are luminance neutral and blue costs no third cosine.
+    vec3 stripe = vec3(1.0);
+    if (lp_subpixels > 0.0) {
+        float sinc = boxSinc(f.x);
+        float ac   = lp_subpixels * sinc * fade.x;
+        vec2 rg = 1.0 + ac * vec2(COS_TAU_6 * cosX.x + SIN_TAU_6 * sinX.x,
+                                  -cosX.x);
+        stripe = vec3(rg, 3.0 - rg.x - rg.y);
+
+        // A column mesh and the stripes share a pitch, so whichever stripe
+        // lands on the dark line is dimmed. Divide the cast back out; M must be
+        // the BOX-FILTERED amplitude or it overshoots where the filter bites.
+        float M = amp.x * sinc;
+        vec3 corr = 1.0 - 0.5 * M * ac * vec3(COS_TAU_6, -1.0, COS_TAU_6);
+        // sqrt() below halves any deviation on the way to the encoded value,
+        // so the correction is halved here to match.
+        stripe /= sqrt(max(corr, 1e-3));
+
+        if (lp_layout >= 0.5) {
+            stripe = stripe.bgr;
+        }
+    }
+
+    // Treating the encoding as a gamma of 2 makes sqrt(linear * m) equal
+    // encoded * sqrt(m), so one square root replaces the decode and re-encode.
+    // Brightness rides the pattern, so the clamp lands on the product.
+    vec3 m = sqrt(max(stripe * (gain * lp_brightness), 0.0));
+
+    // The base is clamped because pow(0, g) is undefined and returns NaN on
+    // real drivers. 1e-8, not 1e-5, which would lift pure black to 1/255.
+    if (abs(lp_gamma - 1.0) > 0.001) {
+        color = pow(max(color, 1e-8), vec3(lp_gamma));
+    }
+
+    vec3 outc = color * m;
+
+    FragColor = vec4(clamp(outc, 0.0, 1.0), 1.0);
+}
+
+
+#endif

--- a/skeleton/BASE/Shaders/glsl/pixel-perfect.glsl
+++ b/skeleton/BASE/Shaders/glsl/pixel-perfect.glsl
@@ -1,0 +1,175 @@
+// pixel-perfect v8 - uniform pixel blocks and colour controls.
+// -----------------------------------------------------------------------------
+// Licence: MIT - Copyright (c) 2026 sinedied
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions: the above copyright
+// notice and this permission notice shall be included in all copies or
+// substantial portions of the Software. THE SOFTWARE IS PROVIDED "AS IS",
+// WITHOUT WARRANTY OF ANY KIND.
+// -----------------------------------------------------------------------------
+// PARAMETERS
+//
+//   pp_brightness    0.50 - 4.00  Output gain. 1.00 disables it.
+//   pp_contrast      0.00 - 2.00  Contrast. 1.00 disables it.
+//   pp_saturation    0.00 - 2.00  Colour intensity. 1.00 disables it.
+//   pp_gamma         0.50 - 2.00  Output gamma. 1.00 disables it.
+//   pp_temperature  -1.00 - 1.00  Warm above 0, cool below. 0.00 is off.
+//   pp_tint         -1.00 - 1.00  Green above 0, magenta below. 0.00 is off.
+// -----------------------------------------------------------------------------
+// A clean upscale: every source pixel becomes an even block, with no shimmer
+// and no blur. The plain, fast default when you want the picture and nothing
+// else, plus simple colour controls for tuning it to a screen.
+//
+// Notes:
+// - Needs a LINEAR filter, set in the preset. Under NEAREST the scale becomes
+//   ordinary nearest-neighbour and the picture gets ragged edges.
+// - Render at the output resolution, 1:1 with the display.
+// - Brightness above 1.00 clips, may create pattern artifacts against the
+//   pixel grid unless the output is an integer scale.
+
+#pragma parameter pp_brightness  "Brightness"               1.00  0.50 4.00 0.05
+#pragma parameter pp_contrast    "Contrast"                 1.00  0.00 2.00 0.05
+#pragma parameter pp_saturation  "Saturation"               1.00  0.00 2.00 0.05
+#pragma parameter pp_gamma       "Gamma"                    1.00  0.50 2.00 0.05
+#pragma parameter pp_temperature "Cool / warm balance"      0.00 -1.00 1.00 0.01
+#pragma parameter pp_tint        "Magenta / green balance"  0.00 -1.00 1.00 0.01
+
+#if defined(VERTEX)
+
+#if __VERSION__ >= 130
+#define COMPAT_VARYING out
+#define COMPAT_ATTRIBUTE in
+#define COMPAT_TEXTURE texture
+#else
+#define COMPAT_VARYING varying
+#define COMPAT_ATTRIBUTE attribute
+#define COMPAT_TEXTURE texture2D
+#endif
+
+#ifdef GL_ES
+#define COMPAT_PRECISION mediump
+#else
+#define COMPAT_PRECISION
+#endif
+
+COMPAT_ATTRIBUTE vec4 VertexCoord;
+COMPAT_ATTRIBUTE vec4 COLOR;
+COMPAT_ATTRIBUTE vec4 TexCoord;
+COMPAT_VARYING vec4 COL0;
+COMPAT_VARYING vec4 TEX0;
+
+uniform mat4 MVPMatrix;
+uniform COMPAT_PRECISION int FrameDirection;
+uniform COMPAT_PRECISION int FrameCount;
+uniform COMPAT_PRECISION vec2 OutputSize;
+uniform COMPAT_PRECISION vec2 TextureSize;
+uniform COMPAT_PRECISION vec2 InputSize;
+
+void main()
+{
+    gl_Position = MVPMatrix * VertexCoord;
+    COL0 = COLOR;
+    TEX0.xy = TexCoord.xy;
+}
+
+#elif defined(FRAGMENT)
+
+#if __VERSION__ >= 130
+#define COMPAT_VARYING in
+#define COMPAT_TEXTURE texture
+out vec4 FragColor;
+#else
+#define COMPAT_VARYING varying
+#define FragColor gl_FragColor
+#define COMPAT_TEXTURE texture2D
+#endif
+
+#ifdef GL_ES
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+precision highp float;
+#else
+precision mediump float;
+#endif
+#define COMPAT_PRECISION highp
+#else
+#define COMPAT_PRECISION
+#endif
+
+uniform COMPAT_PRECISION int FrameDirection;
+uniform COMPAT_PRECISION int FrameCount;
+uniform COMPAT_PRECISION vec2 OutputSize;
+uniform COMPAT_PRECISION vec2 TextureSize;
+uniform COMPAT_PRECISION vec2 InputSize;
+uniform sampler2D Texture;
+COMPAT_VARYING vec4 TEX0;
+
+#ifdef PARAMETER_UNIFORM
+uniform COMPAT_PRECISION float pp_brightness;
+uniform COMPAT_PRECISION float pp_contrast;
+uniform COMPAT_PRECISION float pp_saturation;
+uniform COMPAT_PRECISION float pp_gamma;
+uniform COMPAT_PRECISION float pp_temperature;
+uniform COMPAT_PRECISION float pp_tint;
+#else
+#define pp_brightness 1.0
+#define pp_contrast 1.0
+#define pp_saturation 1.0
+#define pp_gamma 1.0
+#define pp_temperature 0.0
+#define pp_tint 0.0
+#endif
+
+// Rec.709 luma, for the saturation mix. Applied to encoded values: the round
+// trip to linear is the construction the scaler exists to avoid.
+const vec3 LUMA = vec3(0.2126, 0.7152, 0.0722);
+
+void main()
+{
+    // Source texels. The max() guards an unset InputSize, which is 0 and would
+    // make h a zero divisor below.
+    vec2 p = TEX0.xy * TextureSize;
+    vec2 h = max(0.4995 * InputSize / OutputSize, 1e-6);
+
+    // B is the nearest texel boundary; w is the share of the footprint on its
+    // low side. Clamps to 0 or 1 wherever the footprint sits inside one texel,
+    // which is what keeps the blocks flat.
+    vec2 B = floor(p + 0.5);
+    vec2 w = clamp((B - p + h) / (2.0 * h), 0.0, 1.0);
+
+    // One LINEAR tap, handed w: this texcoord asks the texture unit for
+    // exactly mix(T[B], T[B-1], w).
+    vec3 col = COMPAT_TEXTURE(Texture, (B + 0.5 - w) / TextureSize).rgb;
+
+    // Balance first, so saturation sees the tinted colour and 0 really is
+    // monochrome. Brightness, contrast and saturation then fold into one affine
+    // map - do not un-fold it, or the defaults stop being exactly col * 1.0.
+    // Tested separately, not summed, or warm could cancel a cool tint.
+    if (pp_brightness != 1.0 || pp_contrast != 1.0 || pp_saturation != 1.0
+        || pp_temperature != 0.0 || pp_tint != 0.0) {
+        // Warm/cool trades red against blue, tint trades green against both.
+        // Not luma-normalised, so they shift the level a little too.
+        col *= 1.0 + pp_temperature * vec3(1.0, 0.0, -1.0)
+                   + pp_tint        * vec3(-0.5, 1.0, -0.5);
+
+        float ga = pp_brightness * pp_contrast;
+        float gb = 0.5 - 0.5 * pp_contrast;
+        col = col * (ga * pp_saturation)
+            + (dot(col, LUMA) * (ga * (1.0 - pp_saturation)) + gb);
+    }
+
+    // The base is clamped because pow(0, g) is undefined and returns NaN on
+    // real drivers. 1e-8, not 1e-5, which would lift pure black to 1/255.
+    if (abs(pp_gamma - 1.0) > 0.001) {
+        col = pow(max(col, 1e-8), vec3(pp_gamma));
+    }
+
+    // Last, always: a grade or a gamma can leave 0 to 1, the blend cannot.
+    FragColor = vec4(clamp(col, 0.0, 1.0), 1.0);
+}
+
+#endif

--- a/skeleton/BASE/Shaders/lcd-perfect.cfg
+++ b/skeleton/BASE/Shaders/lcd-perfect.cfg
@@ -1,0 +1,15 @@
+minarch_nrofshaders = 1
+minarch_shader1 = lcd-perfect.glsl
+minarch_shader1_filter = LINEAR
+minarch_shader1_srctype = source
+minarch_shader1_scaletype = source
+minarch_shader1_upscale = screen
+minarch_scale_filter = LINEAR
+
+lp_grid = 0.30
+lp_balance = 0.60
+lp_min_pitch = 3.00
+lp_subpixels = 0.00
+lp_layout = 1.00
+lp_brightness = 1.00
+lp_gamma = 1.00

--- a/skeleton/BASE/Shaders/pixel-perfect.cfg
+++ b/skeleton/BASE/Shaders/pixel-perfect.cfg
@@ -1,0 +1,14 @@
+minarch_nrofshaders = 1
+minarch_shader1 = pixel-perfect.glsl
+minarch_shader1_filter = LINEAR
+minarch_shader1_srctype = source
+minarch_shader1_scaletype = source
+minarch_shader1_upscale = screen
+minarch_scale_filter = LINEAR
+
+pp_brightness = 1.00
+pp_contrast = 1.00
+pp_saturation = 1.00
+pp_gamma = 1.00
+pp_temperature = -0.00
+pp_tint = -0.00


### PR DESCRIPTION
## Summary

Adds four single-pass Perfect RetroShaders and matching nx-redux shader presets:

- `crt-perfect`
- `dmg-perfect`
- `lcd-perfect`
- `pixel-perfect`

## Credits

The shaders were created by [@sinedied](https://github.com/sinedied) as part of the [Perfect RetroShaders project](https://github.com/sinedied/perfect-retroshaders) and were originally proposed for NextUI in [LoveRetro/NextUI#796](https://github.com/LoveRetro/NextUI/pull/796).

Many thanks to [@sinedied](https://github.com/sinedied) for creating, optimizing, testing, and sharing these shaders with the retro-handheld community.