### PR TITLE
perf: defer noncritical boot work across TrimUI devices

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -439,11 +439,11 @@ package: tidy
 		mkdir -p ./build/PAYLOAD-$$dev/Tools/.media; \
 		cp ./build/BASE/Tools/.media/bg-$$bg_res.png ./build/PAYLOAD-$$dev/Tools/.media/bg.png; \
 		\
-		echo "  creating device marker $$plat-$$dev"; \
-		touch ./build/PAYLOAD-$$dev/$$plat-$$dev; \
+		echo "  recording device identity $$plat-$$dev"; \
+		printf '%s\n' "$$plat-$$dev" > ./build/PAYLOAD-$$dev/.nx-device; \
 		\
 		echo "  creating MinUI.zip"; \
-		cd ./build/PAYLOAD-$$dev && zip -r MinUI.zip .system .tmp_update Emus Tools $$plat-$$dev && cd ../..; \
+		cd ./build/PAYLOAD-$$dev && zip -r MinUI.zip .system .tmp_update Emus Tools .nx-device && cd ../..; \
 		cp ./build/PAYLOAD-$$dev/MinUI.zip ./build/BASE/MinUI-$$dev.zip; \
 		\
 		echo "  resolving overlays for $$dev ($$overlay_res)"; \

--- a/scripts/tests/test-boot-work.sh
+++ b/scripts/tests/test-boot-work.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+# shellcheck disable=SC1090
+set -eu
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+HELPER="$ROOT/skeleton/SYSTEM/shared/bin/boot-work.sh"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+USERDATA_PATH="$TMP/userdata"
+SHARED_USERDATA_PATH="$TMP/shared"
+NX_POWEROFF_PATH="$TMP/poweroff"
+NX_REBOOT_PATH="$TMP/reboot"
+export NX_POWEROFF_PATH NX_REBOOT_PATH
+mkdir -p "$USERDATA_PATH" "$SHARED_USERDATA_PATH/.minui"
+
+worker() {
+	echo ran >> "$TMP/work"
+}
+
+# Normal boots run work asynchronously.
+. "$HELPER"
+nx_run_boot_work 0 worker
+wait
+[ "$(cat "$TMP/work")" = "ran" ] || {
+	echo "FAIL: deferred worker did not run" >&2
+	exit 1
+}
+
+# A pending shutdown suppresses delayed work.
+: > "$NX_POWEROFF_PATH"
+rm -f "$TMP/work"
+nx_run_boot_work 0 worker
+wait
+[ ! -e "$TMP/work" ] || {
+	echo "FAIL: worker ran after poweroff" >&2
+	exit 1
+}
+rm -f "$NX_POWEROFF_PATH"
+
+# auto.sh keeps the historical synchronous ordering.
+: > "$USERDATA_PATH/auto.sh"
+. "$HELPER"
+rm -f "$TMP/work"
+nx_run_boot_work 30 worker
+[ "$(cat "$TMP/work")" = "ran" ] || {
+	echo "FAIL: auto.sh worker was not synchronous" >&2
+	exit 1
+}
+
+# Auto-resume has the same ordering requirement.
+rm -f "$USERDATA_PATH/auto.sh"
+: > "$SHARED_USERDATA_PATH/.minui/auto_resume.txt"
+. "$HELPER"
+rm -f "$TMP/work"
+nx_run_boot_work 30 worker
+[ "$(cat "$TMP/work")" = "ran" ] || {
+	echo "FAIL: auto-resume worker was not synchronous" >&2
+	exit 1
+}
+
+printf 'PASS: boot-work.sh\n'

--- a/scripts/tests/test-device-info.sh
+++ b/scripts/tests/test-device-info.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+# shellcheck disable=SC1090,SC2034
+set -eu
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+HELPER="$ROOT/skeleton/SYSTEM/shared/bin/device-info.sh"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+check_device() {
+	platform=$1
+	device_id=$2
+	expected_device=$3
+	expected_model=$4
+	printf '%s\n' "$device_id" > "$TMP/.nx-device"
+	(
+		PLATFORM=$platform
+		SDCARD_PATH=$TMP
+		NX_DEVICE_FILE="$TMP/.nx-device"
+		. "$HELPER"
+		[ "$DEVICE" = "$expected_device" ]
+		[ "$TRIMUI_MODEL" = "$expected_model" ]
+		[ "$NX_DEVICE_ID" = "$device_id" ]
+	) || {
+		echo "FAIL: $device_id" >&2
+		exit 1
+	}
+}
+
+check_device tg5040 tg5040-brick brick "Trimui Brick"
+check_device tg5040 tg5040-brickpro brickpro "Trimui Brick Pro"
+check_device tg5040 tg5040-smartpro smartpro "Trimui Smart Pro"
+check_device tg5050 tg5050-smartpros smartpros "Trimui Smart Pro S"
+
+# Before the first extraction, firmware model detection remains available.
+rm -f "$TMP/.nx-device"
+(
+	PLATFORM=tg5040
+	SDCARD_PATH=$TMP
+	NX_DEVICE_FILE="$TMP/.nx-device"
+	NX_MAINUI_MODEL="Trimui Brick Pro"
+	. "$HELPER"
+	[ "$DEVICE" = "brickpro" ]
+) || {
+	echo "FAIL: first-boot model fallback" >&2
+	exit 1
+}
+
+printf 'PASS: device-info.sh\n'

--- a/skeleton/SYSTEM/desktop/paks/MinUI.pak/launch.sh
+++ b/skeleton/SYSTEM/desktop/paks/MinUI.pak/launch.sh
@@ -50,7 +50,7 @@ cd $(dirname "$0")
 
 EXEC_PATH="/tmp/nextui_exec"
 NEXT_PATH="/tmp/next"
-touch "$EXEC_PATH"  && sync
+touch "$EXEC_PATH"
 #while [ -f $EXEC_PATH ]; do
 	nextui.elf # &> $LOGS_PATH/nextui.txt
 	

--- a/skeleton/SYSTEM/shared/bin/boot-work.sh
+++ b/skeleton/SYSTEM/shared/bin/boot-work.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+NX_AUTO_PATH=${NX_AUTO_PATH:-"$USERDATA_PATH/auto.sh"}
+NX_AUTO_RESUME_PATH=${NX_AUTO_RESUME_PATH:-"$SHARED_USERDATA_PATH/.minui/auto_resume.txt"}
+NX_POWEROFF_PATH=${NX_POWEROFF_PATH:-/tmp/poweroff}
+NX_REBOOT_PATH=${NX_REBOOT_PATH:-/tmp/reboot}
+
+NX_DEFER_BOOT_WORK="yes"
+if [ -f "$NX_AUTO_PATH" ] || [ -f "$NX_AUTO_RESUME_PATH" ]; then
+	# Boot hooks and auto-resume rely on platform setup completing first.
+	NX_DEFER_BOOT_WORK="no"
+fi
+
+nx_run_boot_work() {
+	delay=$1
+	shift
+
+	if [ "$NX_DEFER_BOOT_WORK" = "yes" ]; then
+		(
+			sleep "$delay"
+			if [ ! -f "$NX_POWEROFF_PATH" ] && [ ! -f "$NX_REBOOT_PATH" ]; then
+				"$@"
+			fi
+		) &
+	else
+		"$@"
+	fi
+}

--- a/skeleton/SYSTEM/shared/bin/device-info.sh
+++ b/skeleton/SYSTEM/shared/bin/device-info.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+NX_DEVICE_FILE=${NX_DEVICE_FILE:-"$SDCARD_PATH/.nx-device"}
+NX_DEVICE_ID=$(cat "$NX_DEVICE_FILE" 2> /dev/null || true)
+
+case "$PLATFORM:$NX_DEVICE_ID" in
+	tg5040:tg5040-brick)
+		DEVICE="brick"
+		TRIMUI_MODEL="Trimui Brick"
+		;;
+	tg5040:tg5040-brickpro)
+		DEVICE="brickpro"
+		TRIMUI_MODEL="Trimui Brick Pro"
+		;;
+	tg5040:tg5040-smartpro)
+		DEVICE="smartpro"
+		TRIMUI_MODEL="Trimui Smart Pro"
+		;;
+	tg5050:tg5050-smartpros)
+		DEVICE="smartpros"
+		TRIMUI_MODEL="Trimui Smart Pro S"
+		;;
+	*)
+		# First boot has not extracted .nx-device yet, so keep a firmware fallback.
+		TRIMUI_MODEL=${NX_MAINUI_MODEL:-$(strings /usr/trimui/bin/MainUI | grep '^Trimui')}
+		case "$PLATFORM:$TRIMUI_MODEL" in
+			tg5040:"Trimui Brick") DEVICE="brick" ;;
+			tg5040:"Trimui Brick Pro") DEVICE="brickpro" ;;
+			tg5040:*) DEVICE="smartpro" ;;
+			tg5050:*) DEVICE="smartpros" ;;
+		esac
+		;;
+esac
+
+export DEVICE TRIMUI_MODEL NX_DEVICE_ID

--- a/skeleton/SYSTEM/tg5040/dbg/launch.sh
+++ b/skeleton/SYSTEM/tg5040/dbg/launch.sh
@@ -14,12 +14,8 @@ export LOGS_PATH="$USERDATA_PATH/logs"
 export DATETIME_PATH="$SHARED_USERDATA_PATH/datetime.txt"
 export SHARED_SYSTEM_PATH="$SDCARD_PATH/.system/shared"
 
-export TRIMUI_MODEL=`strings /usr/trimui/bin/MainUI | grep ^Trimui`
-if [ "$TRIMUI_MODEL" = "Trimui Brick" ]; then
-	export DEVICE="brick"
-elif [ "$TRIMUI_MODEL" = "Trimui Brick Pro" ]; then
-	export DEVICE="brickpro"
-fi
+# shellcheck disable=SC1091
+. "$SHARED_SYSTEM_PATH/bin/device-info.sh"
 
 export IS_NEXT="yes"
 

--- a/skeleton/SYSTEM/tg5040/paks/MinUI.pak/launch.sh
+++ b/skeleton/SYSTEM/tg5040/paks/MinUI.pak/launch.sh
@@ -47,12 +47,15 @@ mkdir -p "$USERDATA_PATH"
 mkdir -p "$LOGS_PATH"
 mkdir -p "$SHARED_USERDATA_PATH/.minui"
 
-export TRIMUI_MODEL=`strings /usr/trimui/bin/MainUI | grep ^Trimui`
-if [ "$TRIMUI_MODEL" = "Trimui Brick" ]; then
-	export DEVICE="brick"
-elif [ "$TRIMUI_MODEL" = "Trimui Brick Pro" ]; then
+if [ -f "$SDCARD_PATH/tg5040-brickpro" ]; then
+	export TRIMUI_MODEL="Trimui Brick Pro"
 	export DEVICE="brickpro"
+elif [ -f "$SDCARD_PATH/tg5040-brick" ]; then
+	export TRIMUI_MODEL="Trimui Brick"
+	export DEVICE="brick"
 else
+	TRIMUI_MODEL=$(strings /usr/trimui/bin/MainUI | grep '^Trimui')
+	export TRIMUI_MODEL
 	export DEVICE="smartpro"
 fi
 
@@ -128,6 +131,20 @@ echo 1008000 > /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq
 
 keymon.elf & # &> $SDCARD_PATH/keymon.txt &
 
+# /etc writes below still need a writable rootfs. Do this before spawning the
+# delayed OSD and service workers so neither can race the remount.
+mount -o remount,rw /
+
+AUTO_PATH=$USERDATA_PATH/auto.sh
+AUTO_RESUME_PATH="$SHARED_USERDATA_PATH/.minui/auto_resume.txt"
+DEFER_BOOT_WORK="yes"
+if [ -f "$AUTO_PATH" ] || [ -f "$AUTO_RESUME_PATH" ]; then
+	# Preserve the historical ordering guarantees for boot hooks and auto-resume.
+	DEFER_BOOT_WORK="no"
+fi
+
+stage_osd() {
+
 # Overlay-mount the SD card's OSD tree onto /usr/trimui/osd — the SD card is
 # the source of truth for the OSD (daemon binary, assets, toast scripts,
 # every widget). trimui_osdd has /usr/trimui/osd hardcoded in the
@@ -142,10 +159,6 @@ keymon.elf & # &> $SDCARD_PATH/keymon.txt &
 # effect next boot via re-staging. Stock-only files the SD tree doesn't ship
 # (regular.ttf, the 16MB CJK font) show through from the rootfs layer
 # underneath.
-
-# /etc writes below (bt/wifi init scripts) still need a writable rootfs
-mount -o remount,rw /
-
 OSD_DST="/usr/trimui/osd"
 OSD_SRC="$SYSTEM_PATH/osd"
 # The daemon binary and its resolution-locked assets (bg.png, block*.png:
@@ -175,10 +188,26 @@ fi # end osd overlay mount
 
 # Start OSD overlay daemon (system-wide quick menu)
 if [ -x "$OSD_DST/trimui_osdd" ]; then
-	cd "$OSD_DST" && ./trimui_osdd &
+	(
+		cd "$OSD_DST" || exit 1
+		./trimui_osdd
+	) &
 fi
-cd "$SYSTEM_PATH/bin"
+}
 
+if [ "$DEFER_BOOT_WORK" = "yes" ]; then
+	(
+		sleep 2
+		if [ ! -f /tmp/poweroff ] && [ ! -f /tmp/reboot ]; then
+			stage_osd
+		fi
+	) &
+else
+	stage_osd
+fi
+cd "$SYSTEM_PATH/bin" || exit 1
+
+start_services() {
 # Ensure .asoundrc is clean at boot — /etc/asound.conf handles speaker routing.
 # audiomon will write .asoundrc when USB/BT devices connect.
 rm -f $USERDATA_PATH/.asoundrc /tmp/nx_audio_sink
@@ -212,10 +241,21 @@ sshonboot=$(nextval.elf sshOnBoot | sed -n 's/.*"sshOnBoot": \([0-9]*\).*/\1/p')
 if [ "$sshonboot" -eq 1 ]; then
 	/etc/init.d/sshd start > /dev/null 2>&1 &
 fi
+}
+
+if [ "$DEFER_BOOT_WORK" = "yes" ]; then
+	(
+		sleep 1
+		if [ ! -f /tmp/poweroff ] && [ ! -f /tmp/reboot ]; then
+			start_services
+		fi
+	) &
+else
+	start_services
+fi
 
 #######################################
 
-AUTO_PATH=$USERDATA_PATH/auto.sh
 if [ -f "$AUTO_PATH" ]; then
 	"$AUTO_PATH"
 fi
@@ -229,7 +269,9 @@ killall -9 show2.elf > /dev/null 2>&1
 
 EXEC_PATH="/tmp/nextui_exec"
 NEXT_PATH="/tmp/next"
-touch "$EXEC_PATH"  && sync
+# /tmp is volatile; a global sync cannot make this marker survive a reboot and
+# only stalls the first frame when unrelated writes are pending.
+touch "$EXEC_PATH"
 while [ -f $EXEC_PATH ]; do
 	nextui.elf &> $LOGS_PATH/nextui.txt
 

--- a/skeleton/SYSTEM/tg5040/paks/MinUI.pak/launch.sh
+++ b/skeleton/SYSTEM/tg5040/paks/MinUI.pak/launch.sh
@@ -47,17 +47,10 @@ mkdir -p "$USERDATA_PATH"
 mkdir -p "$LOGS_PATH"
 mkdir -p "$SHARED_USERDATA_PATH/.minui"
 
-if [ -f "$SDCARD_PATH/tg5040-brickpro" ]; then
-	export TRIMUI_MODEL="Trimui Brick Pro"
-	export DEVICE="brickpro"
-elif [ -f "$SDCARD_PATH/tg5040-brick" ]; then
-	export TRIMUI_MODEL="Trimui Brick"
-	export DEVICE="brick"
-else
-	TRIMUI_MODEL=$(strings /usr/trimui/bin/MainUI | grep '^Trimui')
-	export TRIMUI_MODEL
-	export DEVICE="smartpro"
-fi
+# shellcheck disable=SC1091
+. "$SHARED_SYSTEM_PATH/bin/device-info.sh"
+# shellcheck disable=SC1091
+. "$SHARED_SYSTEM_PATH/bin/boot-work.sh"
 
 export IS_NEXT="yes"
 
@@ -135,14 +128,6 @@ keymon.elf & # &> $SDCARD_PATH/keymon.txt &
 # delayed OSD and service workers so neither can race the remount.
 mount -o remount,rw /
 
-AUTO_PATH=$USERDATA_PATH/auto.sh
-AUTO_RESUME_PATH="$SHARED_USERDATA_PATH/.minui/auto_resume.txt"
-DEFER_BOOT_WORK="yes"
-if [ -f "$AUTO_PATH" ] || [ -f "$AUTO_RESUME_PATH" ]; then
-	# Preserve the historical ordering guarantees for boot hooks and auto-resume.
-	DEFER_BOOT_WORK="no"
-fi
-
 stage_osd() {
 
 # Overlay-mount the SD card's OSD tree onto /usr/trimui/osd — the SD card is
@@ -195,16 +180,7 @@ if [ -x "$OSD_DST/trimui_osdd" ]; then
 fi
 }
 
-if [ "$DEFER_BOOT_WORK" = "yes" ]; then
-	(
-		sleep 2
-		if [ ! -f /tmp/poweroff ] && [ ! -f /tmp/reboot ]; then
-			stage_osd
-		fi
-	) &
-else
-	stage_osd
-fi
+nx_run_boot_work 2 stage_osd
 cd "$SYSTEM_PATH/bin" || exit 1
 
 start_services() {
@@ -243,21 +219,12 @@ if [ "$sshonboot" -eq 1 ]; then
 fi
 }
 
-if [ "$DEFER_BOOT_WORK" = "yes" ]; then
-	(
-		sleep 1
-		if [ ! -f /tmp/poweroff ] && [ ! -f /tmp/reboot ]; then
-			start_services
-		fi
-	) &
-else
-	start_services
-fi
+nx_run_boot_work 1 start_services
 
 #######################################
 
-if [ -f "$AUTO_PATH" ]; then
-	"$AUTO_PATH"
+if [ -f "$NX_AUTO_PATH" ]; then
+	"$NX_AUTO_PATH"
 fi
 
 cd $(dirname "$0")

--- a/skeleton/SYSTEM/tg5050/paks/MinUI.pak/launch.sh
+++ b/skeleton/SYSTEM/tg5050/paks/MinUI.pak/launch.sh
@@ -47,10 +47,10 @@ mkdir -p "$USERDATA_PATH"
 mkdir -p "$LOGS_PATH"
 mkdir -p "$SHARED_USERDATA_PATH/.minui"
 
-export TRIMUI_MODEL=`strings /usr/trimui/bin/MainUI | grep ^Trimui`
-if [ "$TRIMUI_MODEL" = "Trimui Smart Pro S" ]; then
-	export DEVICE="smartpros"
-fi
+# shellcheck disable=SC1091
+. "$SHARED_SYSTEM_PATH/bin/device-info.sh"
+# shellcheck disable=SC1091
+. "$SHARED_SYSTEM_PATH/bin/boot-work.sh"
 
 export IS_NEXT="yes"
 
@@ -157,6 +157,7 @@ if ! grep -q nx_skip_stock_sshd /etc/init.d/rcS; then
      [ "${i##*/}" = "S50sshd" ] && continue' /etc/init.d/rcS
 fi
 
+stage_osd() {
 OSD_DST="/usr/trimui/osd"
 OSD_SRC="$SYSTEM_PATH/osd"
 if ! grep -q " $OSD_DST " /proc/mounts; then
@@ -166,9 +167,18 @@ if ! grep -q " $OSD_DST " /proc/mounts; then
 fi # end osd overlay mount
 
 # Start OSD overlay daemon (system-wide quick menu)
-cd "$OSD_DST" && ./trimui_osdd &
-cd "$SYSTEM_PATH/bin"
+if [ -x "$OSD_DST/trimui_osdd" ]; then
+	(
+		cd "$OSD_DST" || exit 1
+		./trimui_osdd
+	) &
+fi
+}
 
+nx_run_boot_work 2 stage_osd
+cd "$SYSTEM_PATH/bin" || exit 1
+
+start_services() {
 # Ensure .asoundrc is clean at boot — /etc/asound.conf handles speaker routing.
 # audiomon will write .asoundrc when USB/BT devices connect.
 rm -f $USERDATA_PATH/.asoundrc /tmp/nx_audio_sink
@@ -201,13 +211,15 @@ else
 	# Stop SSH started by stock init system (S50sshd)
 	/etc/init.d/S50sshd stop > /dev/null 2>&1
 fi
+}
+
+nx_run_boot_work 1 start_services
 
 #######################################
 
-AUTO_PATH=$USERDATA_PATH/auto.sh
-if [ -f "$AUTO_PATH" ]; then
+if [ -f "$NX_AUTO_PATH" ]; then
 	echo before auto.sh `cat /proc/uptime` >> /tmp/nextui_boottime
-	"$AUTO_PATH"
+	"$NX_AUTO_PATH"
 	echo after auto.sh `cat /proc/uptime` >> /tmp/nextui_boottime
 fi
 
@@ -220,7 +232,8 @@ killall -9 show2.elf > /dev/null 2>&1
 
 EXEC_PATH="/tmp/nextui_exec"
 NEXT_PATH="/tmp/next"
-touch "$EXEC_PATH"  && sync
+# /tmp is volatile; syncing unrelated files cannot preserve this marker.
+touch "$EXEC_PATH"
 while [ -f $EXEC_PATH ]; do
 	nextui.elf &> $LOGS_PATH/nextui.txt
 

--- a/workspace/all/portmaster/portmaster.c
+++ b/workspace/all/portmaster/portmaster.c
@@ -292,16 +292,15 @@ static void patch_device_info(void) {
 	// Patch the Brick Pro (tg5040) into PortMaster. It shares the plain Brick's
 	// resolution (1024x768) AND SoC (sun50iw10), so both PortMaster detection paths
 	// collapse it into "trimui-brick" (analogsticks=0) — wrong: the Brick Pro has 2
-	// analog sticks. Nothing in stock PortMaster can tell them apart, so distinguish
-	// via the redux SD marker /mnt/SDCARD/tg5040-brickpro and give it its own device.
+	// analog sticks. Read NX Redux's canonical device identity to distinguish it.
 	//
 	// device_info.txt (shell): after the FIXES case has demoted a 1024x768 unit to
-	// "TrimUI Brick" with ANALOG_STICKS=0, upgrade it to Brick Pro when the marker
-	// is present. Inserted just before the "# GLIBC" section (after the case).
+	// "TrimUI Brick" with ANALOG_STICKS=0, upgrade it to Brick Pro when .nx-device
+	// identifies one. Inserted just before the "# GLIBC" section (after the case).
 	snprintf(cmd, sizeof(cmd),
 			 "if ! grep -q 'TrimUI Brick Pro' '%s' 2>/dev/null; then "
 			 "sed -i '/^# GLIBC$/i\\"
-			 "if [ -e \"/mnt/SDCARD/tg5040-brickpro\" ] && [ \"$DEVICE_NAME\" = \"TrimUI Brick\" ]; then DEVICE_NAME=\"TrimUI Brick Pro\"; ANALOG_STICKS=2; fi' '%s';"
+			 "if grep -qx 'tg5040-brickpro' /mnt/SDCARD/.nx-device 2>/dev/null && [ \"$DEVICE_NAME\" = \"TrimUI Brick\" ]; then DEVICE_NAME=\"TrimUI Brick Pro\"; ANALOG_STICKS=2; fi' '%s';"
 			 "fi",
 			 device_info, device_info);
 	system(cmd);
@@ -317,9 +316,9 @@ static void patch_device_info(void) {
 			 // HW_INFO: add trimui-brick-pro after trimui-brick
 			 "sed -i '/\"trimui-brick\": .*\"analogsticks\": 0/a\\"
 			 "    \"trimui-brick-pro\": {\"resolution\": (1024, 768), \"analogsticks\": 2, \"cpu\": \"a133plus\", \"capabilities\": [\"power\"], \"ram\": 1024},' '%s';"
-			 // device_info(): correct trimui-brick -> trimui-brick-pro via the marker
+			 // device_info(): correct trimui-brick -> trimui-brick-pro via .nx-device
 			 "sed -i '/    expand_info(info, override_resolution, override_ram)/i\\"
-			 "    if info[\"device\"] == \"trimui-brick\" and Path(\"/mnt/SDCARD/tg5040-brickpro\").exists(): info[\"device\"] = \"trimui-brick-pro\"' '%s';"
+			 "    if info[\"device\"] == \"trimui-brick\" and Path(\"/mnt/SDCARD/.nx-device\").is_file() and Path(\"/mnt/SDCARD/.nx-device\").read_text().strip() == \"tg5040-brickpro\": info[\"device\"] = \"trimui-brick-pro\"' '%s';"
 			 // Clear Python cache so patched .py files take effect
 			 "rm -rf '%s/pylibs/harbourmaster/__pycache__';"
 			 "fi",

--- a/workspace/all/show2/boot-integration-example.sh
+++ b/workspace/all/show2/boot-integration-example.sh
@@ -125,8 +125,10 @@ install_update_with_progress() {
         rm -rf $SYSTEM_PATH/paks/MinUI.pak
         rm -rf $SYSTEM_PATH/paks/Emus
         rm -rf $SYSTEM_PATH/paks/Tools
-        # device marker files: remove the known set, the zip restores the right one
-        rm -f $SDCARD_PATH/tg5040-brick $SDCARD_PATH/tg5040-brickpro $SDCARD_PATH/tg5040-smartpro $SDCARD_PATH/tg5050-smartpros
+        # The zip restores the canonical device identity. Remove legacy markers too.
+        rm -f "$SDCARD_PATH/.nx-device" "$SDCARD_PATH/tg5040-brick" \
+            "$SDCARD_PATH/tg5040-brickpro" "$SDCARD_PATH/tg5040-smartpro" \
+            "$SDCARD_PATH/tg5050-smartpros"
         
         # Extract
         echo "TEXT:Extracting update..." > /tmp/show2.fifo

--- a/workspace/tg5040/install/boot.sh
+++ b/workspace/tg5040/install/boot.sh
@@ -10,11 +10,14 @@ SYSTEM_PATH="$SDCARD_PATH/.system"
 export LD_LIBRARY_PATH=/usr/trimui/lib:$LD_LIBRARY_PATH
 export PATH=/usr/trimui/bin:$PATH
 
-TRIMUI_MODEL=`strings /usr/trimui/bin/MainUI | grep ^Trimui`
-if [ "$TRIMUI_MODEL" = "Trimui Brick" ]; then
-	DEVICE="brick"
-elif [ "$TRIMUI_MODEL" = "Trimui Brick Pro" ]; then
+if [ -f "$SDCARD_PATH/tg5040-brickpro" ]; then
 	DEVICE="brickpro"
+elif [ -f "$SDCARD_PATH/tg5040-brick" ]; then
+	DEVICE="brick"
+else
+	TRIMUI_MODEL=$(strings /usr/trimui/bin/MainUI | grep '^Trimui')
+	[ "$TRIMUI_MODEL" = "Trimui Brick" ] && DEVICE="brick"
+	[ "$TRIMUI_MODEL" = "Trimui Brick Pro" ] && DEVICE="brickpro"
 fi
 
 # only show splash if either UPDATE_PATH or pakz files exist

--- a/workspace/tg5040/install/boot.sh
+++ b/workspace/tg5040/install/boot.sh
@@ -10,15 +10,20 @@ SYSTEM_PATH="$SDCARD_PATH/.system"
 export LD_LIBRARY_PATH=/usr/trimui/lib:$LD_LIBRARY_PATH
 export PATH=/usr/trimui/bin:$PATH
 
-if [ -f "$SDCARD_PATH/tg5040-brickpro" ]; then
-	DEVICE="brickpro"
-elif [ -f "$SDCARD_PATH/tg5040-brick" ]; then
-	DEVICE="brick"
-else
-	TRIMUI_MODEL=$(strings /usr/trimui/bin/MainUI | grep '^Trimui')
-	[ "$TRIMUI_MODEL" = "Trimui Brick" ] && DEVICE="brick"
-	[ "$TRIMUI_MODEL" = "Trimui Brick Pro" ] && DEVICE="brickpro"
-fi
+DEVICE_ID=$(cat "$SDCARD_PATH/.nx-device" 2> /dev/null)
+case "$DEVICE_ID" in
+	tg5040-brick) DEVICE="brick" ;;
+	tg5040-brickpro) DEVICE="brickpro" ;;
+	tg5040-smartpro) DEVICE="smartpro" ;;
+	*)
+		TRIMUI_MODEL=$(strings /usr/trimui/bin/MainUI | grep '^Trimui')
+		case "$TRIMUI_MODEL" in
+			"Trimui Brick") DEVICE="brick" ;;
+			"Trimui Brick Pro") DEVICE="brickpro" ;;
+			*) DEVICE="smartpro" ;;
+		esac
+		;;
+esac
 
 # only show splash if either UPDATE_PATH or pakz files exist
 SHOW_SPLASH="no"
@@ -116,8 +121,10 @@ if [ -f "$UPDATE_PATH" ]; then
 	rm -rf $SYSTEM_PATH/paks/MinUI.pak
 	rm -rf $SYSTEM_PATH/paks/Emus
 	rm -rf $SYSTEM_PATH/paks/Tools
-	# device marker files: remove the known set, the zip restores the right one
-	rm -f $SDCARD_PATH/tg5040-brick $SDCARD_PATH/tg5040-brickpro $SDCARD_PATH/tg5040-smartpro $SDCARD_PATH/tg5050-smartpros
+	# The zip restores the canonical device identity. Remove legacy markers too.
+	rm -f "$SDCARD_PATH/.nx-device" "$SDCARD_PATH/tg5040-brick" \
+		"$SDCARD_PATH/tg5040-brickpro" "$SDCARD_PATH/tg5040-smartpro" \
+		"$SDCARD_PATH/tg5050-smartpros"
 
 	# Consume the zip ONLY on successful extraction. A corrupt/truncated
 	# MinUI.zip (e.g. the card was pulled before the copy flushed) used to be

--- a/workspace/tg5050/install/boot.sh
+++ b/workspace/tg5050/install/boot.sh
@@ -125,8 +125,10 @@ if [ -f "$UPDATE_PATH" ]; then
 	rm -rf $SYSTEM_PATH/paks/MinUI.pak
 	rm -rf $SYSTEM_PATH/paks/Emus
 	rm -rf $SYSTEM_PATH/paks/Tools
-	# device marker files: remove the known set, the zip restores the right one
-	rm -f $SDCARD_PATH/tg5040-brick $SDCARD_PATH/tg5040-brickpro $SDCARD_PATH/tg5040-smartpro $SDCARD_PATH/tg5050-smartpros
+	# The zip restores the canonical device identity. Remove legacy markers too.
+	rm -f "$SDCARD_PATH/.nx-device" "$SDCARD_PATH/tg5040-brick" \
+		"$SDCARD_PATH/tg5040-brickpro" "$SDCARD_PATH/tg5040-smartpro" \
+		"$SDCARD_PATH/tg5050-smartpros"
 
 	# Consume the zip ONLY on successful extraction. A corrupt/truncated
 	# MinUI.zip (e.g. the card was pulled before the copy flushed) used to be


### PR DESCRIPTION
## Summary

- replace the per-model empty marker files with one canonical `/mnt/SDCARD/.nx-device` value
- centralize device detection for all shipped TrimUI targets:
  - `tg5040-brick`
  - `tg5040-brickpro`
  - `tg5040-smartpro`
  - `tg5050-smartpros`
- share the deferred-boot policy between tg5040 and tg5050
- move OSD staging and audio/connectivity setup off the normal first-frame path on both platforms
- preserve synchronous ordering whenever `auto.sh` or auto-resume is present
- remove unnecessary global `sync` calls after volatile `/tmp/nextui_exec` markers

## Device identity

Each device package now writes its canonical ID to `.nx-device`. `device-info.sh` reads that single value and exports `DEVICE` and `TRIMUI_MODEL`; the expensive `MainUI` inspection remains only as a first-install fallback before `.nx-device` has been extracted.

The Brick Pro PortMaster integration now reads `.nx-device` too. Update paths remove the old empty marker files during migration.

## Fast-boot behavior

`boot-work.sh` provides one platform-independent policy:

- normal menu boot: OSD work is delayed by 2 seconds and audio/connectivity work by 1 second
- `auto.sh` or auto-resume: both workers run synchronously before the hook/game, preserving the previous contract
- pending poweroff/reboot: delayed workers do not start

The worker bodies remain platform-specific because tg5040 and tg5050 use different OSD mounts and radio services.

## Hardware results

TrimUI Brick Pro, stock firmware 1.1.1, NX Redux v1.8.0 card with the PR scripts deployed over ADB:

| Path | Before | After |
| --- | ---: | ---: |
| Normal boot, first frame | 11.01–11.63 s | 9.93–10.37 s |
| `auto.sh`/auto-resume compatibility path | synchronous baseline behavior | ordering verified |

Hardware checks confirmed:

- `.nx-device` resolves to `tg5040-brickpro`, `DEVICE=brickpro`, and `TRIMUI_MODEL=Trimui Brick Pro`
- OSD overlay and `trimui_osdd` start successfully
- `audiomon.elf` and Wi-Fi start successfully
- `auto.sh` sees the OSD mount, Wi-Fi/BT scripts, and audiomon before it runs
- auto-resume still launches the pending game

## Validation

- POSIX shell syntax checks for tg5040, tg5050, desktop, helpers, and tests
- ShellCheck: no findings on added lines; shared helpers/tests pass cleanly
- `scripts/tests/test-device-info.sh`
- `scripts/tests/test-boot-work.sh`
- all other repository shell tests pass except the pre-existing `test-migrate-paks.sh` failure reproduced on unchanged `main` (`legacy community pak not hoisted`)
- `make -n package` confirms every payload records and archives `.nx-device`
- Brick Pro fast path (three consecutive runs: 10.13, 10.03, and 10.05 s), `auto.sh`, auto-resume, OSD, audio, and Wi-Fi tested on hardware

## Residual hardware coverage

The common logic has unit coverage for all four device IDs and both scheduling modes. Physical timing was measured on Brick Pro; Brick, Smart Pro, and Smart Pro S were not available for hardware verification.
