### PR TITLE
perf: reduce UI app transition latency

### DIFF
--- a/workspace/all/common/api.c
+++ b/workspace/all/common/api.c
@@ -408,10 +408,104 @@ int GFX_updateColors(void) {
 	return 0;
 }
 
+// SDL/GL setup and first-frame construction are short, CPU-heavy bursts. Let UI
+// apps use the device's available headroom, then restore the launcher's cap.
+
+#define STARTUP_CPU_MAX_PATH "/sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq"
+#define STARTUP_CPU_PEAK_PATH "/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq"
+#define STARTUP_CPU_BOOST_US 1000000
+
+typedef struct {
+	int restore_max;
+	int peak_max;
+	unsigned int generation;
+	bool active;
+} StartupBoost;
+
+static pthread_mutex_t startup_boost_mutex = PTHREAD_MUTEX_INITIALIZER;
+static StartupBoost startup_boost = {0};
+
+static void GFX_finishStartupBoostLocked(void) {
+	if (!startup_boost.active)
+		return;
+	if (getInt(STARTUP_CPU_MAX_PATH) == startup_boost.peak_max)
+		putInt(STARTUP_CPU_MAX_PATH, startup_boost.restore_max);
+	startup_boost.active = false;
+	startup_boost.generation++;
+}
+
+static void GFX_finishStartupBoost(void) {
+	pthread_mutex_lock(&startup_boost_mutex);
+	GFX_finishStartupBoostLocked();
+	pthread_mutex_unlock(&startup_boost_mutex);
+}
+
+static void* GFX_restoreStartupCPUMax(void* arg) {
+	unsigned int generation = (unsigned int)(uintptr_t)arg;
+	usleep(STARTUP_CPU_BOOST_US);
+	pthread_mutex_lock(&startup_boost_mutex);
+	if (startup_boost.active && startup_boost.generation == generation) {
+		if (getInt(STARTUP_CPU_MAX_PATH) == startup_boost.peak_max)
+			putInt(STARTUP_CPU_MAX_PATH, startup_boost.restore_max);
+		startup_boost.active = false;
+	}
+	pthread_mutex_unlock(&startup_boost_mutex);
+	return NULL;
+}
+
+static void GFX_startStartupBoost(int mode) {
+	if (mode != MODE_MAIN || getenv("NEXTUI_DISABLE_STARTUP_BOOST") ||
+		access(STARTUP_CPU_MAX_PATH, W_OK) != 0 || access(STARTUP_CPU_PEAK_PATH, R_OK) != 0)
+		return;
+
+	pthread_mutex_lock(&startup_boost_mutex);
+	GFX_finishStartupBoostLocked();
+
+	int restore_max = getInt(STARTUP_CPU_MAX_PATH);
+	int peak_max = getInt(STARTUP_CPU_PEAK_PATH);
+	if (restore_max <= 0 || peak_max <= restore_max) {
+		pthread_mutex_unlock(&startup_boost_mutex);
+		return;
+	}
+
+	startup_boost.restore_max = restore_max;
+	startup_boost.peak_max = peak_max;
+	startup_boost.generation++;
+	startup_boost.active = true;
+	putInt(STARTUP_CPU_MAX_PATH, peak_max);
+
+	pthread_t thread;
+	int err = pthread_create(&thread, NULL, GFX_restoreStartupCPUMax,
+		(void*)(uintptr_t)startup_boost.generation);
+	if (err != 0)
+		GFX_finishStartupBoostLocked();
+	pthread_mutex_unlock(&startup_boost_mutex);
+	if (err == 0)
+		pthread_detach(thread);
+}
+
+static bool GFX_timezoneIsApplied(const char* timezone) {
+	if (!timezone || !timezone[0])
+		return false;
+
+	char current_path[512];
+	ssize_t current_len = readlink("/tmp/localtime", current_path, sizeof(current_path) - 1);
+	if (current_len < 0)
+		return false;
+	current_path[current_len] = '\0';
+
+	size_t timezone_len = strlen(timezone);
+	return (size_t)current_len > timezone_len &&
+		current_path[current_len - timezone_len - 1] == '/' &&
+		strcmp(current_path + current_len - timezone_len, timezone) == 0;
+}
+
+
 SDL_Surface* GFX_init(int mode) {
 	// Platform-specific init
 	// This might affect FIXED_SCALE, so do it first
 	PLAT_initPlatform();
+	GFX_startStartupBoost(mode);
 
 	gfx.screen = PLAT_initVideo();
 	gfx.vsync = VSYNC_STRICT;
@@ -422,9 +516,16 @@ SDL_Surface* GFX_init(int mode) {
 
 	CFG_init(GFX_loadSystemFont, GFX_updateColors);
 
-	// We always have to symlink, does not depend on NTP being enabled
+	// Reapply only when the volatile symlink is missing or stale. Persisting an
+	// unchanged timezone on every app launch needlessly commits config and syncs
+	// the hardware clock on the transition path.
 	PLAT_initTimezones();
-	PLAT_setCurrentTimezone(PLAT_getCurrentTimezone());
+	char* timezone = PLAT_getCurrentTimezone();
+	if (timezone) {
+		if (!GFX_timezoneIsApplied(timezone))
+			PLAT_setCurrentTimezone(timezone);
+		free(timezone);
+	}
 
 	PLAT_initLid();
 	LEDS_initLeds();
@@ -513,6 +614,8 @@ void GFX_setScreen(SDL_Surface* s) {
 		gfx.screen = s;
 }
 void GFX_quit(void) {
+	GFX_finishStartupBoost();
+
 	TTF_CloseFont(font.large);
 	TTF_CloseFont(font.medium);
 	TTF_CloseFont(font.small);
@@ -4075,7 +4178,7 @@ FALLBACK_IMPLEMENTATION void PLAT_getTimezones(char timezones[MAX_TIMEZONES][MAX
 	tz_count = 0;
 }
 FALLBACK_IMPLEMENTATION char* PLAT_getCurrentTimezone() {
-	return "Foo/Bar";
+	return strdup("Foo/Bar");
 }
 FALLBACK_IMPLEMENTATION void PLAT_setCurrentTimezone(const char* tz) {}
 FALLBACK_IMPLEMENTATION bool PLAT_getNetworkTimeSync(void) {

--- a/workspace/all/common/generic_video.c
+++ b/workspace/all/common/generic_video.c
@@ -782,9 +782,12 @@ void PLAT_setShaders(int nr) {
 }
 
 static void clearVideo(void) {
+	SDL_FillRect(vid.screen, NULL, SDL_transparentBlack);
+	SDL_UpdateTexture(vid.stream_layer1, NULL, vid.screen->pixels, vid.screen->pitch);
+	SDL_SetRenderTarget(vid.renderer, NULL);
+	SDL_SetRenderDrawColor(vid.renderer, 0, 0, 0, 255);
 	for (int i = 0; i < 3; i++) {
 		SDL_RenderClear(vid.renderer);
-		SDL_FillRect(vid.screen, NULL, SDL_transparentBlack);
 		SDL_RenderCopy(vid.renderer, vid.stream_layer1, NULL, NULL);
 		SDL_RenderPresent(vid.renderer);
 	}
@@ -880,7 +883,6 @@ void PLAT_quitVideo(void) {
 		free(overlay_path);
 
 	SDL_QuitSubSystem(SDL_INIT_VIDEO);
-	system("cat /dev/zero > /dev/fb0 2>/dev/null");
 }
 
 void PLAT_clearVideo(SDL_Surface* screen) {

--- a/workspace/all/nextui/nextui.c
+++ b/workspace/all/nextui/nextui.c
@@ -158,7 +158,6 @@ int main(int argc, char* argv[]) {
 	GFX_clear(screen);
 
 	IndicatorType show_setting = INDICATOR_NONE;
-	PWR_setCPUSpeed(CPU_SPEED_MENU);
 
 	folderbgbmp = NULL;
 
@@ -435,6 +434,7 @@ int main(int argc, char* argv[]) {
 				if (!first_frame_stamped) {
 					first_frame_stamped = true;
 					bootStamp("first frame");
+					PWR_setCPUSpeed(CPU_SPEED_MENU);
 				}
 			}
 
@@ -510,10 +510,9 @@ int main(int argc, char* argv[]) {
 		}
 	}
 
-	// Fast exit when launching a game — skip full cleanup to minimize
-	// delay. The OS reclaims all memory/FDs on process exit. The parent
-	// shell script reads /tmp/next only after nextui.elf exits.
-	if (startgame) {
+	// External launches replace this process, so the OS can reclaim its memory,
+	// descriptors, and worker threads. The parent reads /tmp/next only after exit.
+	if (startgame || exists("/tmp/next")) {
 		GFX_quit();
 		_exit(0);
 	}


### PR DESCRIPTION
## Summary

- briefly raise `MODE_MAIN` UI apps to the hardware CPU ceiling during SDL/GL and menu startup, then restore the launcher-selected cap after one second or synchronously during teardown
- avoid rewriting an already-correct timezone configuration on every process launch
- replace the slow unbounded `/dev/zero` framebuffer write on video teardown with an explicit black SDL texture upload across the swapchain
- keep NextUI's startup boost through its first frame and use the existing fast process-exit path for every external handoff, not only games

## Brick Pro measurements

| Path | Before | After |
|---|---:|---:|
| Settings process start → first frame | 1.39 s | 0.66 s |
| `/tmp/next` creation → Settings process | 0.97 s | ~0.40 s |
| NextUI process start → first frame | 1.16 s | 0.83–0.87 s |
| Settings B press → NextUI first frame | ~2.1 s | 1.19 s |

The previous teardown spent about 0.9 s between writing `/tmp/next` and exiting NextUI, dominated by `cat /dev/zero > /dev/fb0`. The updated black-frame path reduces that handoff substantially without leaving stale content.

The startup boost uses `cpuinfo_max_freq`, preserves the incoming cap, and only restores it if the app has not selected another cap itself. Early-exit restoration was verified separately so a launched game/tool cannot inherit the temporary peak.

## Validation

- rebased onto NX Redux `v1.9.0` (`6ce8631d`)
- cross-built NextUI and Settings for tg5040 and tg5050
- repeated automated Settings open/close cycles on TrimUI Brick Pro
- verified CPU cap returns to 600 MHz after the one-second window and after an early app exit
- verified Settings and NextCommander handoffs render correctly with no stale framebuffer content
- reboot smoke test passed with the optimized binaries
- post-reboot Settings open/exit was confirmed on the physical device; the device owner reports the transitions feel noticeably snappier
- tg5050 hardware was not available; coverage there is compile-only

The unrelated shell catalog tests remain environment-dependent on the host (`unzip` payload preflight), and `test-migrate-paks.sh` retains its existing `legacy community pak not hoisted` failure.
